### PR TITLE
Fix form validations

### DIFF
--- a/backend/utilities/inputValidator.js
+++ b/backend/utilities/inputValidator.js
@@ -110,7 +110,9 @@ const validateUserCreation = async (req, res, next) => {
 };
 
 const validatePasswordReset = async (req, res, next) => {
-  const { password, confirmPassword, resetToken, userId } = req.body;
+  const {
+    password, confirmPassword, resetToken, userId,
+  } = req.body;
   let errors = [];
 
   const userIdError = await validateField(userId, 'userId');

--- a/backend/utilities/inputValidator.js
+++ b/backend/utilities/inputValidator.js
@@ -23,8 +23,8 @@ const validateField = async (value, fieldName) => {
       if (!/^[a-zA-Z0-9]+$/.test(value)) {
         return createDetail(fieldName, value, 'invalid characters');
       }
-      if (value.length < 3) {
-        return createDetail(fieldName, value, 'minimum length 3 characters');
+      if (value.length < 2) {
+        return createDetail(fieldName, value, 'minimum length 2 characters');
       }
       if (await User.findOne({ username: value })) {
         return createDetail(fieldName, value, 'not unique');
@@ -47,8 +47,8 @@ const validateField = async (value, fieldName) => {
       if (!/^[a-zA-Z0-9 ]+$/.test(value)) {
         return createDetail(fieldName, value, 'invalid characters');
       }
-      if (value.length < 3) {
-        return createDetail(fieldName, value, 'minimum length 3 characters');
+      if (value.length < 2) {
+        return createDetail(fieldName, value, 'minimum length 2 characters');
       }
   }
   return '';
@@ -84,7 +84,13 @@ const validateResetToken = async (token, userId) => {
 
 const validateUserCreation = async (req, res, next) => {
   const {
-    username, email, firstname, language, lastname, password, confirmPassword,
+    username,
+    email,
+    firstname,
+    language,
+    lastname,
+    password,
+    confirmPassword,
   } = req.body;
   let errors = [];
 
@@ -104,9 +110,7 @@ const validateUserCreation = async (req, res, next) => {
 };
 
 const validatePasswordReset = async (req, res, next) => {
-  const {
-    password, confirmPassword, resetToken, userId,
-  } = req.body;
+  const { password, confirmPassword, resetToken, userId } = req.body;
   let errors = [];
 
   const userIdError = await validateField(userId, 'userId');

--- a/frontend/src/components/user/LoginForm.js
+++ b/frontend/src/components/user/LoginForm.js
@@ -8,7 +8,6 @@ import { useHistory } from 'react-router-dom';
 import useField from '../../hooks/useField';
 import useModal from '../../hooks/useModal';
 import authService from '../../services/auth';
-import sharedFunctions from '../../utils/sharedFunctions';
 
 import InputField from './InputField';
 import RecoveryLinkForm from '../user/RecoveryLinkForm';
@@ -38,8 +37,8 @@ const useStyles = makeStyles((theme) => ({
 
 const LoginForm = ({ setUser }) => {
   const history = useHistory();
-  const email = useField('email', 'email', 'login-email');
-  const password = useField('password', 'password', 'login-password');
+  const email = useField('email', 'loginEmail', 'login-email');
+  const password = useField('password', 'loginPassword', 'login-password');
   const [alert, setAlert] = useState({
     show: false,
     message: '',
@@ -50,6 +49,24 @@ const LoginForm = ({ setUser }) => {
 
   const handleLogin = async (event) => {
     event.preventDefault();
+    if (email.value === '') {
+      email.setValues({
+        ...email.values,
+        helperText: 'required',
+        error: true,
+      });
+      return;
+    }
+
+    if (password.value === '') {
+      password.setValues({
+        ...password.values,
+        helperText: 'required',
+        error: true,
+      });
+      return;
+    }
+
     try {
       await authService.login(email.value, password.value);
       const decoded = jwt_decode(localStorage.getItem('token'));
@@ -58,9 +75,10 @@ const LoginForm = ({ setUser }) => {
     } catch (err) {
       switch (err.response.data.statusCode) {
         case 400:
-          sharedFunctions.showErrors(err.response.data.details, {
-            email,
-            password,
+          setAlert({
+            show: true,
+            message: 'Invalid email or password',
+            severity: 'error',
           });
           break;
         case 500:
@@ -91,7 +109,10 @@ const LoginForm = ({ setUser }) => {
           Login
         </Typography>
         {alert.show && (
-          <Alert severity={alert.severity} onClose={() => setAlert({ ...alert, show: false })}>
+          <Alert
+            severity={alert.severity}
+            onClose={() => setAlert({ ...alert, show: false })}
+          >
             {alert.message}
           </Alert>
         )}

--- a/frontend/src/components/user/MyProfile/Index.js
+++ b/frontend/src/components/user/MyProfile/Index.js
@@ -51,9 +51,9 @@ const useStyles = makeStyles((theme) => ({
 const MyProfile = ({ user, setUser }) => {
   const [userData, setUserData] = useState({ language: '' });
 
-  const username = useField('text', 'username', 'update-username');
-  const firstName = useField('text', 'name', 'update-firsname');
-  const lastName = useField('text', 'name', 'update-lastname');
+  const username = useField('text', 'updateUsername', 'update-username');
+  const firstName = useField('text', 'updateName', 'update-firstname');
+  const lastName = useField('text', 'updateName', 'update-lastname');
   const email = useField('email', 'email', 'update-email');
   const oldPassword = useField('password', 'password', 'update-old-password');
   const password = useField('password', 'password', 'update-password');

--- a/frontend/src/components/user/MyProfile/UpdateInformation.js
+++ b/frontend/src/components/user/MyProfile/UpdateInformation.js
@@ -47,10 +47,7 @@ const UpdateInformation = (props) => {
       data.lastname = lastName.value;
     if (lang && lang.code !== userData.language) data.language = lang.code;
 
-    if (Object.keys(data).length !== 0) {
-      console.log('data');
-      await handleUpdate(data, setAlert);
-    }
+    if (Object.keys(data).length !== 0) await handleUpdate(data, setAlert);
   };
 
   return lang ? (

--- a/frontend/src/components/user/MyProfile/UpdateInformation.js
+++ b/frontend/src/components/user/MyProfile/UpdateInformation.js
@@ -30,21 +30,27 @@ const UpdateInformation = (props) => {
     { label: 'Russian', code: 'ru' },
   ];
 
-	useEffect(() => {
-		setLang(langOptions.find((lang) => lang.code === userData.language));
-	}, [userData.language]);
+  useEffect(() => {
+    setLang(langOptions.find((lang) => lang.code === userData.language));
+  }, [userData.language]);
 
   const handleInformationUpdate = async (event) => {
     event.preventDefault();
 
     const data = {};
-    if (username.value) data.username = username.value;
-    if (email.value) data.email = email.value;
-    if (firstName.value) data.firstname = firstName.value;
-    if (lastName.value) data.lastname = lastName.value;
-    if (lang) data.language = lang.code;
+    if (username.value && username.value !== userData.username)
+      data.username = username.value;
+    if (email.value && email.value !== userData.email) data.email = email.value;
+    if (firstName.value && firstName.value !== userData.firstName)
+      data.firstname = firstName.value;
+    if (lastName.value && lastName.value !== userData.lastName)
+      data.lastname = lastName.value;
+    if (lang && lang.code !== userData.language) data.language = lang.code;
 
-    await handleUpdate(data, setAlert);
+    if (Object.keys(data).length !== 0) {
+      console.log('data');
+      await handleUpdate(data, setAlert);
+    }
   };
 
   return lang ? (
@@ -100,15 +106,15 @@ const UpdateInformation = (props) => {
 };
 
 UpdateInformation.propTypes = {
-	classes: PropTypes.object.isRequired,
-	userData: PropTypes.object.isRequired,
-	username: PropTypes.object.isRequired,
-	firstName: PropTypes.object.isRequired,
-	lastName: PropTypes.object.isRequired,
-	email: PropTypes.object.isRequired,
-	alert: PropTypes.object.isRequired,
-	setAlert: PropTypes.func.isRequired,
-	handleUpdate: PropTypes.func.isRequired,
+  classes: PropTypes.object.isRequired,
+  userData: PropTypes.object.isRequired,
+  username: PropTypes.object.isRequired,
+  firstName: PropTypes.object.isRequired,
+  lastName: PropTypes.object.isRequired,
+  email: PropTypes.object.isRequired,
+  alert: PropTypes.object.isRequired,
+  setAlert: PropTypes.func.isRequired,
+  handleUpdate: PropTypes.func.isRequired,
 };
 
 export default UpdateInformation;

--- a/frontend/src/hooks/useField.js
+++ b/frontend/src/hooks/useField.js
@@ -22,7 +22,7 @@ const useField = (type, field, id) => {
         setValues({
           value: newValue,
           error: false,
-          helperText: t('form.correct'),
+          helperText: newValue ? t('form.correct') : '',
         });
       })
       .catch((err) => {

--- a/frontend/src/utils/sharedFunctions.js
+++ b/frontend/src/utils/sharedFunctions.js
@@ -1,6 +1,7 @@
 const sharedFunctions = {};
 
 sharedFunctions.showErrors = (errors, params) => {
+  console.log(errors);
   errors.map((detail) => {
     if (detail.param === 'username') {
       params.username.setValues({
@@ -8,20 +9,24 @@ sharedFunctions.showErrors = (errors, params) => {
         helperText: detail.reason,
         error: true,
       });
-    } else if (detail.param === 'firstName') {
+    } else if (detail.param === 'firstname') {
       params.firstName.setValues({
         ...params.firstName.values,
         helperText: detail.reason,
         error: true,
       });
-    } else if (detail.param === 'lastName') {
+    } else if (detail.param === 'lastname') {
       params.lastName.setValues({
         ...params.lastName.values,
         helperText: detail.reason,
         error: true,
       });
     } else if (detail.param === 'email') {
-      params.email.setValues({ ...params.email.values, helperText: detail.reason, error: true });
+      params.email.setValues({
+        ...params.email.values,
+        helperText: detail.reason,
+        error: true,
+      });
     } else if (detail.param === 'password') {
       params.password.setValues({
         ...params.password.values,

--- a/frontend/src/utils/sharedFunctions.js
+++ b/frontend/src/utils/sharedFunctions.js
@@ -1,7 +1,6 @@
 const sharedFunctions = {};
 
 sharedFunctions.showErrors = (errors, params) => {
-  console.log(errors);
   errors.map((detail) => {
     if (detail.param === 'username') {
       params.username.setValues({

--- a/frontend/src/utils/validationSchema.js
+++ b/frontend/src/utils/validationSchema.js
@@ -14,7 +14,12 @@ const schema = yup.object().shape({
   email: yup.string().email('form.email'),
   password: yup
     .string()
-    .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{6,})/, 'form.passwordFormat'),
+    .matches(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{6,})/,
+      'form.passwordFormat'
+    ),
+  loginEmail: yup.string(),
+  loginPassword: yup.string(),
 });
 
 export default schema;

--- a/frontend/src/utils/validationSchema.js
+++ b/frontend/src/utils/validationSchema.js
@@ -3,13 +3,13 @@ import * as yup from 'yup';
 const schema = yup.object().shape({
   username: yup
     .string()
+    .min(2, 'form.minLen')
     .matches(/^[a-zA-Z0-9]+$/, 'form.nameFormat')
-    .min(1, 'form.minLen')
     .max(45, 'form.maxLen'),
   name: yup
     .string()
+    .min(2, 'form.minLen')
     .matches(/^[a-zA-Z0-9]+$/, 'form.nameFormat')
-    .min(1, 'form.minLen')
     .max(45, 'form.maxLen'),
   email: yup.string().email('form.email'),
   password: yup
@@ -20,6 +20,24 @@ const schema = yup.object().shape({
     ),
   loginEmail: yup.string(),
   loginPassword: yup.string(),
+  updateUsername: yup
+    .string()
+    .matches(/^[a-zA-Z0-9]*$/, 'form.nameFormat')
+    .test(
+      'empty-or-min-2-chars',
+      'form.minLen',
+      (username) => !username || username.length > 1
+    )
+    .max(45, 'form.maxLen'),
+  updateName: yup
+    .string()
+    .test(
+      'empty-or-min-2-chars',
+      'form.minLen',
+      (name) => !name || name.length > 1
+    )
+    .matches(/^[a-zA-Z0-9]*$/, 'form.nameFormat')
+    .max(45, 'form.maxLen'),
 });
 
 export default schema;


### PR DESCRIPTION
Back:
- change username, first name and last name min length to 2 to match front

Front:
- login form: only validate that the fields are required
- fix typo that prevented first and last name errors from the backend to show up
- show 'correct' helper only when field is not empty
- update user form: separate validations to allow empty fields
- update user form: check if field content is different from current and only call backend when there is a change